### PR TITLE
Default char n-gram order for chrf should be set to 6 and beta set to 2

### DIFF
--- a/chrF.py
+++ b/chrF.py
@@ -87,7 +87,7 @@ def get_correct(ngrams_ref, ngrams_test, correct, total):
     return correct, total
 
 
-def f1(correct, total_hyp, total_ref, max_length, beta=3, smooth=0):
+def f1(correct, total_hyp, total_ref, max_length, beta=2, smooth=0):
 
     precision = 0
     recall = 0

--- a/chrF.py
+++ b/chrF.py
@@ -60,7 +60,7 @@ def create_parser():
 
     return parser
 
-def extract_ngrams(words, max_length=4, spaces=False):
+def extract_ngrams(words, max_length=6, spaces=False):
 
     if not spaces:
         words = ''.join(words.split())


### PR DESCRIPTION
@rsennrich perhaps the default value for chrf should be set to 6.

From www.statmt.org/wmt15/pdf/WMT49.pdf and www.statmt.org/wmt16/pdf/W16-2341.pdf , the optimal value for character n-gram order would be 6 instead of 4. 

As for word-level n-gram, the 2nd paper summarized and suggested it to be set to 4:

> WORDF is then calculated on word n-grams and CHRF is calculated on character n-grams. Maxi- mum n-gram length N for both metrics is inves- tigated in previous work, and N=4 is shown to be optimal for WORDF (Popovic ́, 2011), N=6 for CHRF (Popovic ́, 2015).

Also, the beta parameter should be set to 2 instead of 3, section 3 of the 2nd paper:

> β = 2 is the best option both for CHRF 
