### PR TITLE
Using stats.get without lambda to get most_frequent

### DIFF
--- a/learn_bpe.py
+++ b/learn_bpe.py
@@ -194,7 +194,7 @@ def main(infile, outfile, num_symbols, min_frequency=2, verbose=False, is_dict=F
     threshold = max(stats.values()) / 10
     for i in range(num_symbols):
         if stats:
-            most_frequent = max(stats, key=lambda x: (stats[x], x))
+            most_frequent = max(stats, key=stats.get)
 
         # we probably missed the best pair because of pruning; go back to full statistics
         if not stats or (i and stats[most_frequent] < threshold):


### PR DESCRIPTION
Using `dict.get` in the `max` key parameter would work without lambda.

```python
>>> x
{'a': 5, 'b': 5, 'e': 2, 'd': 1, 'g': 1, 'f': 1}
>>> x = {'a': 5, 'b': 5, 'e': 2, 'd': 1, 'g': 1, 'f': 1}
>>> max(x, key=x.get)
'a'
```