### PR TITLE
Fix a bug when second time reading file breaks version

### DIFF
--- a/apply_bpe.py
+++ b/apply_bpe.py
@@ -28,12 +28,12 @@ class BPE(object):
     def __init__(self, codes, merges=-1, separator='@@', vocab=None, glossaries=None):
 
         # check version information
+        codes.seek(0)
         firstline = codes.readline()
         if firstline.startswith('#version:'):
             self.version = tuple([int(x) for x in re.sub(r'(\.0+)*$','', firstline.split()[-1]).split(".")])
         else:
             self.version = (0, 1)
-            codes.seek(0)
 
         self.bpe_codes = [tuple(item.split()) for (n, item) in enumerate(codes) if (n < merges or merges == -1)]
 


### PR DESCRIPTION
Reading BPE codes from the same file twice sets the version to `(0, 1)`. Also, it reads the first line `#version: 0.2` to the dictionary of available codes