### PR TITLE
Improve library usability

### DIFF
--- a/subword_nmt/apply_bpe.py
+++ b/subword_nmt/apply_bpe.py
@@ -47,7 +47,7 @@ class BPE(object):
         for i, item in enumerate(self.bpe_codes):
             if len(item) != 2:
                 sys.stderr.write('Error: invalid line {0} in BPE codes file: {1}\n'.format(i+offset, ' '.join(item)))
-                sys.stderr.write('The line should exist of exactly two subword units, separated by whitespace\n'.format(' '.join(item)))
+                sys.stderr.write('The line should exist of exactly two subword units, separated by whitespace\n')
                 sys.exit(1)
 
         # some hacking to deal with duplicates (only consider first instance)

--- a/subword_nmt/apply_bpe.py
+++ b/subword_nmt/apply_bpe.py
@@ -82,8 +82,13 @@ class BPE(object):
 
     def segment(self, sentence):
         """segment single sentence (whitespace-tokenized string) with BPE encoding"""
+        segments = self.segment_tokens(sentence.strip('\r\n ').split(' '))
+        return ' '.join(segments)
+
+    def segment_tokens(self, tokens):
+        """segment a sequence of tokens with BPE encoding"""
         output = []
-        for word in sentence.strip('\r\n ').split(' '):
+        for word in tokens:
             # eliminate double spaces
             if not word:
                 continue
@@ -101,7 +106,7 @@ class BPE(object):
                 output.append(item + self.separator)
             output.append(new_word[-1])
 
-        return ' '.join(output)
+        return output
 
     def _isolate_glossaries(self, word):
         word_segments = [word]


### PR DESCRIPTION
When using `subword-nmt` as a Python library rather than a script, calling `BPE.segment()` might result in unnecessary string operations.

Consider the following situation, where the user already has a list of tokens and needs a list of segments:
```py
sentence = ' '.join(tokens)
segments = bpe.segment(sentence)
segments = segments.split(' ')
```
... and inside `BPE.segments()`, the reverse of these operations happens on the edges, ie. `sentence` is first split on whitespace, and the segments list is joined to a string before returning.

This pull request adds a new method, `BPE.segment_tokens()`, which accepts an iterable of tokens and returns a list of segments, while leaving the current API unchanged. This allows avoiding superfluous string operations in the described secenario.