### PR TITLE
Extending --glossaries to handle regex

### DIFF
--- a/subword_nmt/tests/test_glossaries.py
+++ b/subword_nmt/tests/test_glossaries.py
@@ -83,12 +83,32 @@ class TestBPEIsolateGlossariesMethod(unittest.TestCase):
         test_case = (orig, exp)
         self._run_test_case(test_case)
 
+class TestRegexIsolateGlossaries(unittest.TestCase):
+
+    def setUp(self):
+
+        amock = mock.MagicMock()
+        amock.readline.return_value = 'something'
+        glossaries = ["<country>\w*</country>", "<name>\w*</name>", "\d+"]
+        self.bpe = BPE(amock, glossaries=glossaries)
+
+    def _run_test_case(self, test_case):
+        orig, expected = test_case
+        out = self.bpe._isolate_glossaries(orig)
+        self.assertEqual(out, expected)
+
+    def test_regex_glossaries(self):
+        orig = 'wordlike<country>USA</country>word10001word<name>Manuel</name>word<country>USA</country>'
+        exp = ['wordlike', '<country>USA</country>', 'word', '10001', 'word', '<name>Manuel</name>', 'word', '<country>USA</country>']
+        test_case = (orig, exp)
+        self._run_test_case(test_case) 
+
 def encode_mock(segment, x2, x3, x4, x5, x6, x7, glosses):
     if segment in glosses:
         return (segment,)
     else:
         l = len(segment)
-        return (segment[:l/2], segment[l/2:])
+        return (segment[:l//2], segment[l//2:])
 
 class TestBPESegmentMethod(unittest.TestCase):
 


### PR DESCRIPTION
Extends the functionality of the --glossaries argument of apply_bpe.py to enable using regex.

For example:
```python apply_bpe.py -c codes_file -i input_text --glossaries "string1" "string2" "<tag>\w*</tag>" "\d+"```
will ensure *string1*, *string2*, words enclosed in `<tag> </tag>` and numbers will not be split by BPE and will be isolated from other subwords.

Helps with #49.