### PR TITLE
Fix best practice instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ are the two languages):
 Learn byte pair encoding on the concatenation of the training text, and get resulting vocabulary for each:
 
     cat {train_file}.L1 {train_file}.L2 | subword-nmt learn-bpe -s {num_operations} -o {codes_file}
-    subword-nmt apply-bpe -c {codes_file} < {train_file}.L1 && subword-nmt get-vocab --train_file {codes_file} --vocab_file {vocab_file}.L1
-    subword-nmt apply-bpe -c {codes_file} < {train_file}.L2 && subword-nmt get-vocab --train_file {codes_file} --vocab_file {vocab_file}.L2
+    subword-nmt apply-bpe -c {codes_file} < {train_file}.L1 > {tmp}.L1 && subword-nmt get-vocab --train_file {tmp}.L1 --vocab_file {vocab_file}.L1
+    subword-nmt apply-bpe -c {codes_file} < {train_file}.L2 > {tmp}.L2 && subword-nmt get-vocab --train_file {tmp}.L2 --vocab_file {vocab_file}.L2
 
 more conventiently, you can do the same with with this command:
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ are the two languages):
 Learn byte pair encoding on the concatenation of the training text, and get resulting vocabulary for each:
 
     cat {train_file}.L1 {train_file}.L2 | subword-nmt learn-bpe -s {num_operations} -o {codes_file}
-    subword-nmt apply-bpe -c {codes_file} < {train_file}.L1 > {tmp}.L1 && subword-nmt get-vocab --train_file {tmp}.L1 --vocab_file {vocab_file}.L1
-    subword-nmt apply-bpe -c {codes_file} < {train_file}.L2 > {tmp}.L2 && subword-nmt get-vocab --train_file {tmp}.L2 --vocab_file {vocab_file}.L2
+    subword-nmt apply-bpe -c {codes_file} < {train_file}.L1 > {tmp}.L1 && subword-nmt get-vocab -i {tmp}.L1 -o {vocab_file}.L1
+    subword-nmt apply-bpe -c {codes_file} < {train_file}.L2 > {tmp}.L2 && subword-nmt get-vocab -i {tmp}.L2 -o {vocab_file}.L2
 
 more conventiently, you can do the same with with this command:
 


### PR DESCRIPTION
I think there is a mistake in the best practice instructions.

- the first apply-bpe output should be saved or piped through
- get-vocab should get a temporary training corpus as input that has BPE applied without vocabulary threshold.
- get_vocab now takes -i and -o arguments (or stdin)

I fixed it in this PR. Please check it :-) 