### PR TITLE
Use a single regex match with optional operator

### DIFF
--- a/subword_nmt/apply_bpe.py
+++ b/subword_nmt/apply_bpe.py
@@ -182,7 +182,7 @@ def encode(orig, bpe_codes, bpe_codes_reverse, vocab, separator, version, cache,
     if orig in cache:
         return cache[orig]
 
-    if re.match('^({})$'.format('|'.join(glossaries))):
+    if re.match('^({})$'.format('|'.join(glossaries)), orig):
         cache[orig] = (orig,)
         return (orig,)
 

--- a/subword_nmt/apply_bpe.py
+++ b/subword_nmt/apply_bpe.py
@@ -182,10 +182,9 @@ def encode(orig, bpe_codes, bpe_codes_reverse, vocab, separator, version, cache,
     if orig in cache:
         return cache[orig]
 
-    for glossary in glossaries:
-        if re.match('^'+glossary+'$', orig):
-            cache[orig] = (orig,)
-            return (orig,)
+    if re.match('^({})$'.format('|'.join(glossaries))):
+        cache[orig] = (orig,)
+        return (orig,)
 
     if version == (0, 1):
         word = tuple(orig) + ('</w>',)


### PR DESCRIPTION
Instead of iterating the glossaries with multiple regex operations, using the optional operator `|`, it should be able to check for regex matches in one regex operation. E.g. 

```python
>>> glossaries = ['USA', '34']
>>> word = '34'
>>> re.match('^({})$'.format('|'.join(glossaries)), word)
<_sre.SRE_Match object; span=(0, 2), match='34'>

>>> word = '1934USABUSA'
>>> re.match('^({})$'.format('|'.join(glossaries)), word) # Returns None
```
