### PR TITLE
Add --seed command-line argument to apply-bpe

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ On top of the basic BPE implementation, this repository supports:
 
 - BPE dropout (Provilkov, Emelianenko and Voita, 2019): https://arxiv.org/abs/1910.13267
   use the argument `--dropout 0.1` for `subword-nmt apply-bpe` to randomly drop out possible merges.
-  Doing this on the training corpus can improve quality of the final system; at test time, use BPE without dropout
+  Doing this on the training corpus can improve quality of the final system; at test time, use BPE without dropout.
+  In order to obtain reproducible results, argument `--seed` can be used to set the random seed.
 
 - support for glossaries:
   use the argument `--glossaries` for `subword-nmt apply-bpe` to provide a list of words and/or regular expressions

--- a/subword_nmt/apply_bpe.py
+++ b/subword_nmt/apply_bpe.py
@@ -169,6 +169,10 @@ def create_parser(subparsers=None):
         help="Glossaries. Words matching any of the words/regex provided in glossaries will not be affected "+
              "by the BPE (i.e. they will neither be broken into subwords, nor concatenated with other subwords. "+
              "Can be provided as a list of words/regex after the --glossaries argument. Enclose each regex in quotes.")
+    parser.add_argument(
+        '--seed', type=int, default=None,
+        metavar="S",
+        help="Random seed for the random number generators (e.g. for BPE dropout with --dropout).")
 
     return parser
 
@@ -360,6 +364,8 @@ if __name__ == '__main__':
         if args.glossaries:
             args.glossaries = [g.decode('UTF-8') for g in args.glossaries]
 
+    if args.seed is not None:
+        random.seed(args.seed)
 
     bpe = BPE(args.codes, args.merges, args.separator, vocabulary, args.glossaries)
 


### PR DESCRIPTION
This PR is motivated by issue https://github.com/rsennrich/subword-nmt/issues/90 :
> Given that BPE dropout introduces randomness in the result of apply-bpe, it would be great if there was a --seed command-line argument that made it reproducible.

A new optional command-line argument `--seed` is added to apply-bpe. If the argument is provided, the random seed is set in main function before calling `bpe.process_line`.

If subword-nmt is used programmatically, it is possible to directly set the random variable there, before invoking the `BPE` object, so there is no need for special changes to support setting the random seed when used programmatically. Therefore, only the command-line argument was added in this PR.

An alternative solution that would be perhaps more suited for programmatic use of subword-bpe would be to change the function definitions that receive a `dropout` parameter to also receive a `seed` argument and then use a local [`Random` object](https://docs.python.org/3/library/random.html#random.Random) instead of the shared-state global one, but this would complicate things unnecessarily. 