### PR TITLE
solve unicode errors when reading the bpe codes file

### DIFF
--- a/subword_nmt/apply_bpe.py
+++ b/subword_nmt/apply_bpe.py
@@ -44,7 +44,7 @@ class BPE(object):
             self.version = (0, 1)
             codes.seek(0)
 
-        self.bpe_codes = [tuple(item.strip('\r\n ').split(' ')) for (n, item) in enumerate(codes) if (n < merges or merges == -1)]
+        self.bpe_codes = [tuple(item.strip('\r\n ').split(' ')) for (n, item) in enumerate(codes.read().rstrip('\n').split('\n')) if (n < merges or merges == -1)]
 
         for i, item in enumerate(self.bpe_codes):
             if len(item) != 2:
@@ -307,7 +307,7 @@ def isolate_glossary(word, glossary):
     """
     Isolate a glossary present inside a word.
 
-    Returns a list of subwords. In which all 'glossary' glossaries are isolated 
+    Returns a list of subwords. In which all 'glossary' glossaries are isolated
 
     For example, if 'USA' is the glossary and '1934USABUSA' the word, the return value is:
         ['1934', 'USA', 'B', 'USA']


### PR DESCRIPTION
`codecs` considers some special Unicode characters, such as \u2028, \u2029, as new line separators.
This may lead to errors when loading the bpe codes file.

For example,  in the following file, `. \u2028</w>` will be read as two lines, raising the error "The line should exist of exactly two subword units, separated by whitespace".
```
se u
. \u2028</w>
p as
```
