### PR TITLE
Add note about BPE-Dropout during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ On top of the basic BPE implementation, this repository supports:
   use the argument `--dropout 0.1` for `subword-nmt apply-bpe` to randomly drop out possible merges.
   Doing this on the training corpus can improve quality of the final system; at test time, use BPE without dropout.
   In order to obtain reproducible results, argument `--seed` can be used to set the random seed.
+  
+  **Note:** In the original paper, the authors used BPE-Dropout on each new batch separately. You can copy the training corpus several times to get similar behavior to obtain multiple segmentations for the same sentence.
 
 - support for glossaries:
   use the argument `--glossaries` for `subword-nmt apply-bpe` to provide a list of words and/or regular expressions


### PR DESCRIPTION
Dear Rico, 

I have been approached several times by people who have learned models by applying BPE-Dropout only once on the training corpus. I think this note can save many GPU-hours in the future.

Ivan